### PR TITLE
bug: sort inline properties recusively to prevent flaky struct field order

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -67,6 +67,15 @@ func sortProperties(props []*Property) []*Property {
 	for _, n := range names {
 		sorted = append(sorted, pMap[n])
 	}
+
+	// In case the top level property contains another property internally,
+	// sort them recursively.
+	for _, p := range sorted {
+		if p.InlineProperties != nil {
+			p.InlineProperties = sortProperties(p.InlineProperties)
+		}
+	}
+
 	return sorted
 }
 

--- a/parser.go
+++ b/parser.go
@@ -261,7 +261,6 @@ func (p *Parser) ParseResources() (map[string]Resource, error) {
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to parse %s", id)
 			}
-			fld.InlineProperties = sortProperties(fld.InlineProperties)
 			flds = append(flds, fld)
 		}
 		rs.Properties = sortProperties(flds)


### PR DESCRIPTION
In case a resource contains another resource, it is set to `InlineProperties` . This InlineProperties is also a Property, so this can nest infinitely.

This PR introduces recursive property sort. Without this, nested properties are not sorted, so suppose "an object of an array of an object..." is not sorted.