### PR TITLE
fix goreleaser deprecated flag

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ steps.gh-app-auth.outputs.token }}


### PR DESCRIPTION
https://goreleaser.com/deprecations/#-rm-dist

![スクリーンショット 2024-10-01 13 34 14](https://github.com/user-attachments/assets/9cb0451c-7aa9-4407-9f0e-1259db39bdfb)

It seems like `--rm-dist` does not work now, replace...