### PR TITLE
fix: type:object + properties なしのフィールドを interface{} で生成する

### DIFF
--- a/resource.go
+++ b/resource.go
@@ -148,7 +148,11 @@ func (pr *Property) Field(op FormatOption) []byte {
 		t = fmt.Sprintf("*%s", varfmt.PublicVarName(normalize(pr.refToStructName())))
 	case pr.Types.Contains(schema.ObjectType) && !pr.IsRefToMainResource():
 		// inline object
-		t = pr.inlineOjbect(op)
+		if len(pr.InlineProperties) == 0 {
+			t = "interface{}"
+		} else {
+			t = pr.inlineOjbect(op)
+		}
 	}
 	if !pr.Required {
 		empty = ",omitempty"

--- a/resource_test.go
+++ b/resource_test.go
@@ -135,3 +135,36 @@ func TestResourceStruct(t *testing.T) {
 	}
 	t.Logf("%s", ss)
 }
+
+func TestEmptyObjectPropertyField(t *testing.T) {
+	cases := []struct {
+		Prop     Property
+		Expected string
+	}{
+		{
+			Prop: Property{
+				Name:     "options",
+				Types:    []schema.PrimitiveType{schema.ObjectType},
+				PropType: PropTypeObject,
+				Required: true,
+			},
+			Expected: "Options interface{} `json:\"options\" schema:\"options\"`",
+		},
+		{
+			Prop: Property{
+				Name:     "metadata",
+				Types:    []schema.PrimitiveType{schema.ObjectType},
+				PropType: PropTypeObject,
+				Required: false,
+			},
+			Expected: "Metadata interface{} `json:\"metadata,omitempty\" schema:\"metadata\"`",
+		},
+	}
+
+	for _, c := range cases {
+		result := string(c.Prop.Field(FormatOption{Schema: true}))
+		if result != c.Expected {
+			t.Errorf("expected %q, got %q", c.Expected, result)
+		}
+	}
+}


### PR DESCRIPTION
## 変更内容

`resource.go` の `Field` メソッドで、`type: object` かつ `InlineProperties` が空（properties が未定義）のフィールドを
空の `struct{}` ではなく `interface{}` として生成するよう修正。

## 背景

WebAuthn の Options/Credential のように、JSON の構造が動的で事前に型定義できないフィールドに対応するため。
例: `options: {type: object}` → 修正前: `Options struct{}` → 修正後: `Options interface{}`

## 後方互換性

`InlineProperties` が空でない場合（properties が定義されている場合）は従来どおりインライン struct を生成するため、
既存のスキーマへの影響なし。